### PR TITLE
Build all targets

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -72,7 +72,10 @@ jobs:
         -DBUILD_EXTENSIONS="autocomplete"
 
     - name: Build Tests
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j ${{steps.cpus.outputs.count}} -t driver_tests
+      run: cmake 
+        --build ${{github.workspace}}/build 
+        --config ${{env.BUILD_TYPE}} 
+        -j ${{steps.cpus.outputs.count}} 
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/examples/AutoCompletion/main.cpp
+++ b/examples/AutoCompletion/main.cpp
@@ -18,9 +18,9 @@ int main(int argc, char *argv[]) {
 	query.exec("INSERT INTO employee VALUES ('Bert', 5500);");
 	query.exec("INSERT INTO employee VALUES ('Tina', 6500);");
 
-	QLineEdit *lineEdit = new QLineEdit();
+	auto lineEdit = new QLineEdit();
 
-	auto *completer = new QCompleter(lineEdit);
+	auto completer = new QCompleter(lineEdit);
 	lineEdit->setCompleter(completer);
 	completer->setCompletionMode(QCompleter::UnfilteredPopupCompletion);
 	completer->setCaseSensitivity(Qt::CaseSensitivity::CaseInsensitive);


### PR DESCRIPTION
Only the tests were build.

With ccache, the build time is much lower now so that we can build everything.