### PR TITLE
feat: CMake option for DuckDB version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project ("QtDuckDBDriver" VERSION 0.2.1)
 option(QTDUCKDB_BUILD_EXAMPLES OFF)
 option(QTDUCKDB_BUILD_TESTS ON)
 option(QTDUCKDB_WARNING_AS_ERRORS OFF)
+set(QTDUCKDB_DUCKDB_VERSION "1.1.3" CACHE STRING "Version of DuckDB which should be included")
 
 include(cmake/DetectQtVersion.cmake)
 include(cmake/QtDuckDBProperties.cmake)

--- a/QtDuckDBDriver/CMakeLists.txt
+++ b/QtDuckDBDriver/CMakeLists.txt
@@ -2,11 +2,11 @@
 # project specific logic here.
 #
 
-find_package(Qt${QT_VERSION} REQUIRED COMPONENTS Sql)
+find_package(Qt${QTDUCKDB_QT_VERSION} REQUIRED COMPONENTS Sql)
 
 add_library(QtSqlPrivate INTERFACE)
-target_include_directories(QtSqlPrivate INTERFACE "${Qt${QT_VERSION}Sql_PRIVATE_INCLUDE_DIRS}")
-set_property(TARGET QtSqlPrivate PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Qt${QT_VERSION}Sql_PRIVATE_INCLUDE_DIRS}")
+target_include_directories(QtSqlPrivate INTERFACE "${Qt${QTDUCKDB_QT_VERSION}Sql_PRIVATE_INCLUDE_DIRS}")
+set_property(TARGET QtSqlPrivate PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Qt${QTDUCKDB_QT_VERSION}Sql_PRIVATE_INCLUDE_DIRS}")
 
 include(../cmake/get_cpm.cmake)
 CPMAddPackage("gh:duckdb/duckdb#v${QTDUCKDB_DUCKDB_VERSION}")
@@ -27,7 +27,7 @@ set_property(TARGET QtDuckDBDriver PROPERTY INTERPROCEDURAL_OPTIMIZATION_DEBUG F
 set_property(TARGET QtDuckDBDriver PROPERTY COMPILE_WARNING_AS_ERROR ${QTDUCKDB_WARNING_AS_ERRORS})
 
 # disables sign conversion for qt5 as qt6 is the future and they fixed a lot of data types there
-if (NOT "${QT_VERSION}" STREQUAL "5")
+if (NOT "${QTDUCKDB_QT_VERSION}" STREQUAL "5")
     target_compile_options(QtDuckDBDriver PRIVATE
             $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
                 -Wall -Wextra -Wconversion -pedantic-errors -Wsign-conversion>

--- a/QtDuckDBDriver/CMakeLists.txt
+++ b/QtDuckDBDriver/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(QtSqlPrivate INTERFACE "${Qt${QT_VERSION}Sql_PRIVATE_
 set_property(TARGET QtSqlPrivate PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Qt${QT_VERSION}Sql_PRIVATE_INCLUDE_DIRS}")
 
 include(../cmake/get_cpm.cmake)
-CPMAddPackage("gh:duckdb/duckdb#v1.1.3")
+CPMAddPackage("gh:duckdb/duckdb#v${QTDUCKDB_DUCKDB_VERSION}")
 
 get_property(duckdb_include_dirs TARGET duckdb_static PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 set_property(TARGET duckdb_static PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${duckdb_include_dirs}")

--- a/QtDuckDBDriver/Qt5Compat.h
+++ b/QtDuckDBDriver/Qt5Compat.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <QMetaObject>
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QTDUCKDB_QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 
 #include <QLatin1String>
 

--- a/QtDuckDBDriver/Qt5Compat.h
+++ b/QtDuckDBDriver/Qt5Compat.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <QMetaObject>
 
-#if QTDUCKDB_QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 
 #include <QLatin1String>
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Full example can be found in the [example directory](./examples/TableWidget/## )
 
 DuckDB will be linked statically.  
 
+You can set a specific DuckDB Version with the CMake varialbe `QTDUCKDB_DUCKDB_VERSION`. For Example `QTDUCKDB_DUCKDB_VERSION="1.1.3"` for building this plugin with DuckDB v1.1.3.
+
 
 For pre-build dlls, please choose the right version (See [Qt Doc about plugin version](https://doc.qt.io/qt-6/deployment-plugins.html#loading-and-verifying-plugins-dynamically))  
 *tl;dr*: don't use the plugin on Qt version below the version it was build for.

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Full example can be found in the [example directory](./examples/TableWidget/## )
 
 DuckDB will be linked statically.  
 
-You can set a specific DuckDB Version with the CMake varialbe `QTDUCKDB_DUCKDB_VERSION`. For Example `QTDUCKDB_DUCKDB_VERSION="1.1.3"` for building this plugin with DuckDB v1.1.3.
+CMake options:
+- `QTDUCKDB_DUCKDB_VERSION` specify the DuckDB version you want to build and link e.g. "1.1.3". It will be automatically downloaded
+- `QTDUCKDB_QT_VERSION` specify the version you want to use. Default: tries to autodetect which is installed. Prefers 6 over 5
 
 
 For pre-build dlls, please choose the right version (See [Qt Doc about plugin version](https://doc.qt.io/qt-6/deployment-plugins.html#loading-and-verifying-plugins-dynamically))  
 *tl;dr*: don't use the plugin on Qt version below the version it was build for.
-
-You can manually select the Qt Version with the cmake variable `QT_VERSION`== 5 or == 6. Otherwise, the auto detection will select the highest version.
 
 
 ## Prebuild MSVC DLL in the artifacts

--- a/cmake/DetectQtVersion.cmake
+++ b/cmake/DetectQtVersion.cmake
@@ -12,5 +12,5 @@ if(NOT Qt6_FOUND)
     endif()
 endif()
 
-set(QT_VERSION ${_QT_VERSION} CACHE STRING "Qt Version")
-message(STATUS "Using Qt${QT_VERSION}")
+set(QTDUCKDB_QT_VERSION ${_QT_VERSION} CACHE STRING "Qt Version")
+message(STATUS "Using Qt${QTDUCKDB_QT_VERSION}")

--- a/cmake/QtDuckDBProperties.cmake
+++ b/cmake/QtDuckDBProperties.cmake
@@ -1,12 +1,12 @@
 function(add_qtduckdb_properties TARGET)
-    find_package(Qt${QT_VERSION} REQUIRED COMPONENTS Test Sql Widgets)
+    find_package(Qt${QTDUCKDB_QT_VERSION} REQUIRED COMPONENTS Test Sql Widgets)
     target_link_libraries(${TARGET} PRIVATE Qt::Sql QtDuckDBDriver)
     set_property(TARGET ${TARGET} PROPERTY AUTOMOC ON)
     set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
     set_property(TARGET QtDuckDBDriver PROPERTY COMPILE_WARNING_AS_ERROR ${QTDUCKDB_WARNING_AS_ERRORS})
 
     # disables sign conversion for qt5 as qt6 is the future and they fixed a lot of data types there
-    if (NOT "${QT_VERSION}" STREQUAL "5")
+    if (NOT "${QTDUCKDB_QT_VERSION}" STREQUAL "5")
         target_compile_options(${TARGET} PRIVATE
             $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
                 -Wall -Wextra -Wconversion -pedantic-errors -Wsign-conversion>


### PR DESCRIPTION
Adds the CMake option `QTDUCKDB_DUCKDB_VERSION` where you can control the version of the included DuckDB version.