### PR TITLE
chore: Update DuckDB to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project ("QtDuckDBDriver" VERSION 0.2.1)
 option(QTDUCKDB_BUILD_EXAMPLES OFF)
 option(QTDUCKDB_BUILD_TESTS ON)
 option(QTDUCKDB_WARNING_AS_ERRORS OFF)
-set(QTDUCKDB_DUCKDB_VERSION "1.1.3" CACHE STRING "Version of DuckDB which should be included")
+set(QTDUCKDB_DUCKDB_VERSION "1.2.0" CACHE STRING "Version of DuckDB which should be included")
 
 include(cmake/DetectQtVersion.cmake)
 include(cmake/QtDuckDBProperties.cmake)

--- a/QtDuckDBDriver/QtDuckDBDriver.h
+++ b/QtDuckDBDriver/QtDuckDBDriver.h
@@ -19,7 +19,6 @@ struct DuckDBConnectionHandle {
 #define Q_EXPORT_SQLDRIVER_DUCKDB Q_SQL_EXPORT
 #endif
 
-class QSqlResult;
 class QDuckDBDriverPrivate;
 
 class Q_EXPORT_SQLDRIVER_DUCKDB QDuckDBDriver : public QSqlDriver {

--- a/cmake/QtDuckDBProperties.cmake
+++ b/cmake/QtDuckDBProperties.cmake
@@ -1,9 +1,9 @@
 function(add_qtduckdb_properties TARGET)
     find_package(Qt${QTDUCKDB_QT_VERSION} REQUIRED COMPONENTS Test Sql Widgets)
-    target_link_libraries(${TARGET} PRIVATE Qt::Sql QtDuckDBDriver)
+    target_link_libraries(${TARGET} PRIVATE Qt::Sql)
     set_property(TARGET ${TARGET} PROPERTY AUTOMOC ON)
     set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
-    set_property(TARGET QtDuckDBDriver PROPERTY COMPILE_WARNING_AS_ERROR ${QTDUCKDB_WARNING_AS_ERRORS})
+    set_property(TARGET ${TARGET} PROPERTY COMPILE_WARNING_AS_ERROR ${QTDUCKDB_WARNING_AS_ERRORS})
 
     # disables sign conversion for qt5 as qt6 is the future and they fixed a lot of data types there
     if (NOT "${QTDUCKDB_QT_VERSION}" STREQUAL "5")

--- a/cmake/QtDuckDBProperties.cmake
+++ b/cmake/QtDuckDBProperties.cmake
@@ -1,6 +1,7 @@
 function(add_qtduckdb_properties TARGET)
     find_package(Qt${QTDUCKDB_QT_VERSION} REQUIRED COMPONENTS Test Sql Widgets)
     target_link_libraries(${TARGET} PRIVATE Qt::Sql)
+    add_dependencies(${TARGET} QtDuckDBDriver)
     set_property(TARGET ${TARGET} PROPERTY AUTOMOC ON)
     set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
     set_property(TARGET ${TARGET} PROPERTY COMPILE_WARNING_AS_ERROR ${QTDUCKDB_WARNING_AS_ERRORS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,11 @@ add_test(NAME driver_tests COMMAND driver_tests)
 add_qtduckdb_properties(driver_tests)
 target_link_libraries(driver_tests PRIVATE Qt::Test)
 
+
 # for duckdb internal access
-target_link_libraries(driver_tests PRIVATE duckdb_static)
-target_include_directories(driver_tests PRIVATE $<TARGET_PROPERTY:QtDuckDBDriver,INCLUDE_DIRECTORIES>)
+if (WIN32)
+    target_link_libraries(driver_tests PRIVATE QtDuckDBDriver)
+else()
+    target_link_libraries(driver_tests PRIVATE duckdb_static)
+    target_include_directories(driver_tests PRIVATE $<TARGET_PROPERTY:QtDuckDBDriver,INCLUDE_DIRECTORIES>)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_executable(driver_tests "driver_tests.h" "main.cpp")
 add_test(NAME driver_tests COMMAND driver_tests)
-set_tests_properties(driver_tests PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
 add_qtduckdb_properties(driver_tests)
 target_link_libraries(driver_tests PRIVATE Qt::Test)
+
+# for duckdb internal access
+target_link_libraries(driver_tests PRIVATE duckdb_static)
+target_include_directories(driver_tests PRIVATE $<TARGET_PROPERTY:QtDuckDBDriver,INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
Release notes of duckdb 1.2.0: https://github.com/duckdb/duckdb/releases/tag/v1.2.0